### PR TITLE
Added brazilian protuguese to supported target languages

### DIFF
--- a/src/DeepL.php
+++ b/src/DeepL.php
@@ -97,8 +97,8 @@ class DeepL
         'PL',
         'RU',
         'ZH',
-        'JA'
-
+        'JA',
+        'PT-BR',
     );
 
     /**


### PR DESCRIPTION
This PR adds brazilian protuguese as a supported target language.